### PR TITLE
Add data source for ami, replace hard-coded ami id

### DIFF
--- a/environments.tf
+++ b/environments.tf
@@ -1,22 +1,20 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.0"
-    }
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
   }
-}
-
-provider "aws" {
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-  region = var.aws_region
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  owners = ["099720109477"] # Canonical
 }
 
 resource "aws_instance" "salt_instance" {
-  ami = "ami-0d50e5e845c552faf"
+  ami           = data.aws_ami.ubuntu.id
   instance_type = "t2.micro"
-  count = var.instance_count
+  count         = var.instance_count
   tags = {
     Name = "salt_instance-${count.index}"
   }

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
+}

--- a/variables.tf
+++ b/variables.tf
@@ -7,12 +7,12 @@ variable "aws_secret_key" {
 }
 
 variable "aws_region" {
-  type = string
+  type    = string
   default = "us-west-1"
 }
 
 variable "instance_count" {
-  type = number
+  type    = number
   default = 3
 }
 


### PR DESCRIPTION
- Add a data source to environments.tf for looking up the latest ami version of Ubuntu Jammy Jellyfish 22.04, replace the hard-coded ami id
- Separate provider blocks into providers.tf
- Minor syntax changes to all .tf files via $terraform fmt