### PR TITLE
Add sg.tf (security group)

### DIFF
--- a/sg.tf
+++ b/sg.tf
@@ -1,0 +1,35 @@
+resource "aws_security_group" "allow_http_https" {
+  name        = "allow_http_https"
+  description = "Allow HTTP and HTTPS inbound traffic"
+  vpc_id      = aws_vpc.salt_environment.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_http" {
+  security_group_id = aws_security_group.allow_http_https.id
+
+  description = "Allow HTTP inbound"
+  ip_protocol = "tcp"
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 80
+  to_port     = 80
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_https" {
+  security_group_id = aws_security_group.allow_http_https.id
+
+  description = "Allow HTTPS inbound"
+  ip_protocol = "tcp"
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 443
+  to_port     = 443
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_out" {
+  security_group_id = aws_security_group.allow_http_https.id
+
+  description = "Allow all traffic outbound"
+  ip_protocol = "-1"
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 0
+  to_port     = 0
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -11,10 +11,10 @@ resource "aws_internet_gateway" "igw" {
 }
 
 resource "aws_subnet" "salt_public_subnet" {
-  vpc_id     = aws_vpc.salt_environment.id
-  cidr_block = "10.0.${1+count.index}.0/24"
-  count = "${length(data.aws_availability_zones.available.names)}"
-  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  vpc_id                  = aws_vpc.salt_environment.id
+  cidr_block              = "10.0.${1 + count.index}.0/24"
+  count                   = length(data.aws_availability_zones.available.names)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = true
 }
 
@@ -28,7 +28,7 @@ resource "aws_route_table" "public_rt" {
 }
 
 resource "aws_route_table_association" "public_rta" {
-  count = "${length(data.aws_availability_zones.available.names)}"
-  subnet_id = "${element(aws_subnet.salt_public_subnet.*.id, count.index)}"
+  count          = length(data.aws_availability_zones.available.names)
+  subnet_id      = element(aws_subnet.salt_public_subnet.*.id, count.index)
   route_table_id = aws_route_table.public_rt.id
 }


### PR DESCRIPTION
- Add sg.tf
- Add a security group resource in the vpc that gets created by this config.
- Add ingress/egress rule resources for HTTP in, HTTPS in, and all traffic out.
- Minor syntax changes to vpc.tf and sg.tf via $terraform fmt