### PR TITLE
Improve ec2 instance creation

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,17 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_ami" "js_ami" {
+  most_recent = true
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  owners = ["099720109477"] # Canonical
+}
+

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,21 +1,12 @@
-data "aws_ami" "ubuntu" {
-  most_recent = true
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
-  }
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-  owners = ["099720109477"] # Canonical
-}
 
-resource "aws_instance" "instance" {
-  ami           = data.aws_ami.ubuntu.id
-  instance_type = "t2.micro"
+
+resource "aws_instance" "js_instance" {
+  ami           = data.aws_ami.js_ami.id
+  instance_type = var.aws_instance_type
   count         = var.instance_count
+  subnet_id     = element(aws_subnet.js_subnet.*.id, count.index)
+
   tags = {
-    Name = "js-cloud-${count.index}"
+    Name = "js-cloud-${count.index + 1}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,11 @@ variable "aws_secret_key" {
   type = string
 }
 
+variable "aws_instance_type" {
+  type    = string
+  default = "t2.micro"
+}
+
 variable "aws_region" {
   type    = string
   default = "us-west-1"
@@ -15,6 +20,8 @@ variable "instance_count" {
   type    = number
   default = 3
 }
+
+
 
 
 

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,9 +1,9 @@
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
 resource "aws_vpc" "js_vpc" {
   cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "js-cloud-vpc"
+  }
 }
 
 resource "aws_internet_gateway" "js_internet_gateway" {


### PR DESCRIPTION
- Add dynamic subnet allocation to ec2 instance resource block (ec2.tf).  It will "round-robin" the created instances into the number of subnets that this config creates (1 per AZ).  The instances will be evenly distributed across the region's AZs.
- Add data.tf and move both data sources to it.
- Add a variable for instance type to variables.tf
- Add a name (tag) "js-cloud-vpc" for vpc resource to vpc.tf