### PR TITLE
Add apache webserver to ec2 instance creation

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -1,12 +1,21 @@
-
-
 resource "aws_instance" "js_instance" {
-  ami           = data.aws_ami.js_ami.id
-  instance_type = var.aws_instance_type
-  count         = var.instance_count
-  subnet_id     = element(aws_subnet.js_subnet.*.id, count.index)
+  ami                    = data.aws_ami.js_ami.id
+  instance_type          = var.aws_instance_type
+  vpc_security_group_ids = [aws_security_group.js_security_group.id]
+  count                  = var.instance_count
+  subnet_id              = element(aws_subnet.js_subnet.*.id, count.index)
+  user_data              = <<-EOF
+  #!/bin/bash
+  sudo apt update -y
+  sudo apt install apache2 -y
+  echo "<h1>Hi, I'm part of js-cloud!  I'm $(curl http://checkip.amazonaws.com)</h1>" > /var/www/html/index.html
+  EOF
 
   tags = {
     Name = "js-cloud-${count.index + 1}"
   }
+}
+
+output "instance_public_ip" {
+  value = aws_instance.js_instance[*].public_ip
 }

--- a/sg.tf
+++ b/sg.tf
@@ -2,34 +2,34 @@ resource "aws_security_group" "js_security_group" {
   name        = "allow-http-https"
   description = "Allow HTTP and HTTPS inbound traffic"
   vpc_id      = aws_vpc.js_vpc.id
-}
 
-resource "aws_vpc_security_group_ingress_rule" "allow_http" {
-  security_group_id = aws_security_group.js_security_group.id
+  ingress {
+    description      = "Allow HTTP inbound"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
 
-  description = "Allow HTTP inbound"
-  ip_protocol = "tcp"
-  cidr_ipv4   = "0.0.0.0/0"
-  from_port   = 80
-  to_port     = 80
-}
+  ingress {
+    description      = "Allow HTTPS inbound"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
 
-resource "aws_vpc_security_group_ingress_rule" "allow_https" {
-  security_group_id = aws_security_group.js_security_group.id
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
 
-  description = "Allow HTTPS inbound"
-  ip_protocol = "tcp"
-  cidr_ipv4   = "0.0.0.0/0"
-  from_port   = 443
-  to_port     = 443
-}
-
-resource "aws_vpc_security_group_egress_rule" "allow_all_out" {
-  security_group_id = aws_security_group.js_security_group.id
-
-  description = "Allow all traffic outbound"
-  ip_protocol = "-1"
-  cidr_ipv4   = "0.0.0.0/0"
-  from_port   = 0
-  to_port     = 0
+  tags = {
+    Name = "js-allow-http-https"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,28 +13,10 @@ variable "aws_instance_type" {
 
 variable "aws_region" {
   type    = string
-  default = "us-west-1"
+  default = "us-east-1"
 }
 
 variable "instance_count" {
   type    = number
-  default = 3
+  default = 6
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
- Add bash script to install/run apache2 and overwrite the instance's /var/www/html so that it displays a message with it's public ip (ec2.tf)
- Remove individual sg rule resources, add inline rules to security group resource (sg.tf)
- Fixed spacing in variables.tf and ec2.tf
- Change default values for aws_region and instance_count to us-east-1 and 6.